### PR TITLE
Adding an AEAD Encryption Provider using AES-CBC and HMAC

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -44,6 +44,8 @@ type ProviderConfiguration struct {
 	AESGCM *AESConfiguration
 	// aescbc is the configuration for the AES-CBC transformer.
 	AESCBC *AESConfiguration
+	// aescbchmac is the configuration for the AES-CBC-HMAC transformer.
+	AESCBCHMAC *AESCBCHMACConfiguration
 	// secretbox is the configuration for the Secretbox based transformer.
 	Secretbox *SecretboxConfiguration
 	// identity is the (empty) configuration for the identity transformer.
@@ -59,6 +61,13 @@ type AESConfiguration struct {
 	Keys []Key
 }
 
+// AESCBCHMACConfiguration contains the API configuration for an AESCBCHMAC transformer.
+type AESCBCHMACConfiguration struct {
+	// keys is a list of keys to be used for creating the AES transformer.
+	// Each key has to be 32 bytes long for AES-CBC and 16, 24 or 32 bytes for AES-GCM.
+	Keys []EncryptThenMACKey
+}
+
 // SecretboxConfiguration contains the API configuration for an Secretbox transformer.
 type SecretboxConfiguration struct {
 	// keys is a list of keys to be used for creating the Secretbox transformer.
@@ -72,6 +81,16 @@ type Key struct {
 	Name string
 	// secret is the actual key, encoded in base64.
 	Secret string
+}
+
+// EncryptThenMACKey contains name, encryption secret and signing secret of the provided key for a transformer.
+type EncryptThenMACKey struct {
+	// name is the name of the key to be used while storing data to disk.
+	Name string
+	// encryption secret is the actual key, encoded in base64 used for encryption.
+	EncryptionSecret string
+	// signing secret is the actual key, encoded in base64 used for generating the mac.
+	MACSecret string
 }
 
 // IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -42,6 +42,8 @@ type ProviderConfiguration struct {
 	AESGCM *AESConfiguration `json:"aesgcm,omitempty"`
 	// aescbc is the configuration for the AES-CBC transformer.
 	AESCBC *AESConfiguration `json:"aescbc,omitempty"`
+	// aescbchmac is the configuration for the AES-CBC transformer.
+	AESCBCHMAC *AESCBCHMACConfiguration `json:"aescbchmac,omitempty"`
 	// secretbox is the configuration for the Secretbox based transformer.
 	Secretbox *SecretboxConfiguration `json:"secretbox,omitempty"`
 	// identity is the (empty) configuration for the identity transformer.
@@ -57,6 +59,13 @@ type AESConfiguration struct {
 	Keys []Key `json:"keys"`
 }
 
+// AESCBCHMACConfiguration contains the API configuration for an AESCBCHMAC transformer.
+type AESCBCHMACConfiguration struct {
+	// keys is a list of keys to be used for creating the AES transformer.
+	// Each key has to be 32 bytes long for AES-CBC and 16, 24 or 32 bytes for AES-GCM.
+	Keys []EncryptThenMACKey `json:"keys"`
+}
+
 // SecretboxConfiguration contains the API configuration for an Secretbox transformer.
 type SecretboxConfiguration struct {
 	// keys is a list of keys to be used for creating the Secretbox transformer.
@@ -70,6 +79,16 @@ type Key struct {
 	Name string `json:"name"`
 	// secret is the actual key, encoded in base64.
 	Secret string `json:"secret"`
+}
+
+// EncryptThenMACKey contains name, encryption secret and signing secret of the provided key for a transformer.
+type EncryptThenMACKey struct {
+	// name is the name of the key to be used while storing data to disk.
+	Name string `json:"name"`
+	// encryption secret is the actual key, encoded in base64 used for encryption.
+	EncryptionSecret string `json:"encryptionsecret"`
+	// signing secret is the actual key, encoded in base64 used for generating the mac.
+	MACSecret string `json:"macsecret"`
 }
 
 // IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -61,6 +61,14 @@ const (
             secret: c2VjcmV0IGlzIHNlY3VyZQ==
           - name: key2
             secret: dGhpcyBpcyBwYXNzd29yZA==
+      - aescbchmac:
+          keys:
+          - name: key1
+            encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+            macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+          - name: key2
+            encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+            macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK               
       - secretbox:
           keys:
           - name: key1
@@ -92,6 +100,14 @@ resources:
           secret: c2VjcmV0IGlzIHNlY3VyZQ==
         - name: key2
           secret: dGhpcyBpcyBwYXNzd29yZA==
+    - aescbchmac:
+        keys:
+        - name: key1
+          encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+          macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+        - name: key2
+          encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+          macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK      
     - secretbox:
         keys:
         - name: key1
@@ -125,6 +141,14 @@ resources:
           secret: c2VjcmV0IGlzIHNlY3VyZQ==
         - name: key2
           secret: dGhpcyBpcyBwYXNzd29yZA==
+    - aescbchmac:
+        keys:
+        - name: key1
+          encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+          macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+        - name: key2
+          encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+          macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK           
     - identity: {}
 `
 
@@ -141,6 +165,14 @@ resources:
           secret: c2VjcmV0IGlzIHNlY3VyZQ==
         - name: key2
           secret: dGhpcyBpcyBwYXNzd29yZA==
+    - aescbchmac:
+        keys:
+        - name: key1
+          encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+          macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+        - name: key2
+          encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+          macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK             
     - kms:
         name: testprovider
         endpoint: unix:///tmp/testprovider.sock
@@ -186,6 +218,14 @@ resources:
           secret: c2VjcmV0IGlzIHNlY3VyZQ==
         - name: key2
           secret: dGhpcyBpcyBwYXNzd29yZA==
+    - aescbchmac:
+        keys:
+        - name: key1
+          encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+          macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+        - name: key2
+          encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+          macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK            
 `
 
 	correctConfigWithKMSFirst = `
@@ -210,6 +250,52 @@ resources:
         - name: key2
           secret: dGhpcyBpcyBwYXNzd29yZA==
     - identity: {}
+    - aescbchmac:
+        keys:
+        - name: key1
+          encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+          macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+        - name: key2
+          encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+          macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK      
+    - aesgcm:
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        - name: key2
+          secret: dGhpcyBpcyBwYXNzd29yZA==
+`
+
+	correctConfigWithAesCbcHmacFirst = `
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbchmac:
+        keys:
+        - name: key1
+          encryptionsecret: c2VjcmV0IGlzIHNlY3VyZQ==
+          macsecret: c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK
+        - name: key2
+          encryptionsecret: dGhpcyBpcyBwYXNzd29yZA==
+          macsecret: dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK  
+    - kms:
+        name: testprovider
+        endpoint: unix:///tmp/testprovider.sock
+        cachesize: 10
+    - secretbox:
+        keys:
+        - name: key1
+          secret: YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=
+    - aescbc:
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        - name: key2
+          secret: dGhpcyBpcyBwYXNzd29yZA==
+    - identity: {} 
     - aesgcm:
         keys:
         - name: key1
@@ -307,6 +393,12 @@ func TestLegacyConfig(t *testing.T) {
 							{Name: "key2", Secret: "dGhpcyBpcyBwYXNzd29yZA=="},
 						},
 					}},
+					{AESCBCHMAC: &apiserverconfig.AESCBCHMACConfiguration{
+						Keys: []apiserverconfig.EncryptThenMACKey{
+							{Name: "key1", EncryptionSecret: "c2VjcmV0IGlzIHNlY3VyZQ==", MACSecret: "c2VjcmV0IGhhcyBpbnRlZ3JpdHkgd2l0aCBhIGhtYWMK"},
+							{Name: "key2", EncryptionSecret: "dGhpcyBpcyBwYXNzd29yZA==", MACSecret: "dGhpcyBpcyB0aGUgc2VjcmV0J3Mgc2lnbmluZyBrZXkK"},
+						},
+					}},
 					{Secretbox: &apiserverconfig.SecretboxConfiguration{
 						Keys: []apiserverconfig.Key{
 							{Name: "key1", Secret: "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY="},
@@ -346,6 +438,11 @@ func TestEncryptionProviderConfigCorrect(t *testing.T) {
 		t.Fatalf("error while parsing configuration file: %s.\nThe file was:\n%s", err, correctConfigWithAesCbcFirst)
 	}
 
+	aesCbcHmacFirstTransformerOverrides, err := ParseEncryptionConfiguration(strings.NewReader(correctConfigWithAesCbcHmacFirst))
+	if err != nil {
+		t.Fatalf("error while parsing configuration file: %s.\nThe file was:\n%s", err, correctConfigWithAesCbcHmacFirst)
+	}
+
 	secretboxFirstTransformerOverrides, err := ParseEncryptionConfiguration(strings.NewReader(correctConfigWithSecretboxFirst))
 	if err != nil {
 		t.Fatalf("error while parsing configuration file: %s.\nThe file was:\n%s", err, correctConfigWithSecretboxFirst)
@@ -360,6 +457,7 @@ func TestEncryptionProviderConfigCorrect(t *testing.T) {
 	identityFirstTransformer := identityFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
 	aesGcmFirstTransformer := aesGcmFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
 	aesCbcFirstTransformer := aesCbcFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
+	aesCbcHmacFirstTransformer := aesCbcHmacFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
 	secretboxFirstTransformer := secretboxFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
 	kmsFirstTransformer := kmsFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
 
@@ -372,6 +470,7 @@ func TestEncryptionProviderConfigCorrect(t *testing.T) {
 	}{
 		{aesGcmFirstTransformer, "aesGcmFirst"},
 		{aesCbcFirstTransformer, "aesCbcFirst"},
+		{aesCbcHmacFirstTransformer, "aesCbcHmacFirst"},
 		{secretboxFirstTransformer, "secretboxFirst"},
 		{identityFirstTransformer, "identityFirst"},
 		{kmsFirstTransformer, "kmsFirst"},

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes_cbc_hmac.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes_cbc_hmac.go
@@ -1,0 +1,220 @@
+package aes
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"errors"
+	"hash"
+	"io"
+)
+
+// cipher.AEAD is an interface that implements an Authenticated Encryption with
+// Associated Data scheme. xref: https://golang.org/pkg/crypto/cipher/#AEAD
+// We implement this interface as defined in RFC5116 at:
+// https://tools.ietf.org/html/rfc5116 using CBC + HMAC.
+// The interface definition is replicated in the block comment below for reference.
+/*
+type AEAD interface {
+	// NonceSize returns the size of the nonce that must be passed to Seal
+	// and Open.
+	NonceSize() int
+
+	// Overhead returns the maximum difference between the lengths of a
+	// plaintext and its ciphertext.
+	Overhead() int
+
+	// Seal encrypts and authenticates plaintext, authenticates the
+	// additional data and appends the result to dst, returning the updated
+	// slice. The nonce must be NonceSize() bytes long and unique for all
+	// time, for a given key.
+	//
+	// To reuse plaintext's storage for the encrypted output, use plaintext[:0]
+	// as dst. Otherwise, the remaining capacity of dst must not overlap plaintext.
+	Seal(dst, nonce, plaintext, additionalData []byte) []byte
+
+	// Open decrypts and authenticates ciphertext, authenticates the
+	// additional data and, if successful, appends the resulting plaintext
+	// to dst, returning the updated slice. The nonce must be NonceSize()
+	// bytes long and both it and the additional data must match the
+	// value passed to Seal.
+	//
+	// To reuse ciphertext's storage for the decrypted output, use ciphertext[:0]
+	// as dst. Otherwise, the remaining capacity of dst must not overlap plaintext.
+	//
+	// Even if the function fails, the contents of dst, up to its capacity,
+	// may be overwritten.
+	Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error)
+}
+*/
+
+// aesCbcHmac represents an AES block cipher in CBC mode authenticated with HMAC data
+type aesCbcHmac struct {
+	cipher    cipher.Block
+	hash      hash.Hash
+	nonceSize int
+	tagSize   int
+}
+
+const (
+	achBlockSize         = 16
+	achTagSize           = 16
+	achMinimumTagSize    = 12 // NIST SP 800-38D recommends tags with 12 or more bytes.
+	achStandardNonceSize = 12
+)
+
+// NewACH returns an AEAD which uses the AES block cipher in CBC mode authenticated with HMAC data
+func NewACH(cipher cipher.Block, hash hash.Hash) (cipher.AEAD, error) {
+	return newACHWithNonceAndTagSize(cipher, hash, achStandardNonceSize, achTagSize)
+}
+
+func newACHWithNonceAndTagSize(cipher cipher.Block, hash hash.Hash, nonceSize int, tagSize int) (cipher.AEAD, error) {
+	if tagSize < achMinimumTagSize || tagSize > achBlockSize || tagSize > hash.Size() {
+		return nil, errors.New("aes-cbc-hmac: incorrect tag size given")
+	}
+
+	if cipher.BlockSize() != achBlockSize {
+		return nil, errors.New("aes-cbc-hmac: requires 128-bit block cipher")
+	}
+
+	ach := &aesCbcHmac{cipher: cipher, hash: hash, nonceSize: nonceSize, tagSize: tagSize}
+	return ach, nil
+}
+
+func (ach *aesCbcHmac) NonceSize() int {
+	return ach.nonceSize
+}
+
+func (ach *aesCbcHmac) Overhead() int {
+	return ach.tagSize
+}
+
+func (ach *aesCbcHmac) Seal(dst, nonce, plaintext, data []byte) []byte {
+	if len(nonce) != ach.nonceSize {
+		panic("aes-cbc-hmac: Nonce Length does not match!")
+	}
+	if uint64(len(plaintext)) > ((1<<32)-2)*uint64(ach.cipher.BlockSize()) {
+		panic("aes-cbc-hmac: message is too large")
+	}
+
+	blockSize := achBlockSize
+	paddingSize := blockSize - (len(plaintext) % blockSize)
+	result := make([]byte, blockSize+len(plaintext)+paddingSize)
+
+	// Generate random bytes for iv in first block
+	iv := result[:blockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		panic("aes-cbc-hmac: unable to read sufficient random bytes")
+	}
+
+	// Copy actual plaintext
+	copy(result[blockSize:], plaintext)
+
+	// add PKCS#7 padding for CBC
+	copy(result[blockSize+len(plaintext):], bytes.Repeat([]byte{byte(paddingSize)}, paddingSize))
+
+	// Encrypt
+	mode := cipher.NewCBCEncrypter(ach.cipher, iv)
+	mode.CryptBlocks(result[blockSize:], result[blockSize:])
+
+	// Then MAC
+	// Calculate HMAC input as nonce N + Associated data A + ciphertext
+	// Refer to RFC5116 at: https://tools.ietf.org/html/rfc5116
+	hmacInput := make([]byte, len(nonce)+len(data)+len(result))
+	copy(hmacInput, nonce)
+	hmacInput = append(hmacInput, data...)
+	hmacInput = append(hmacInput, result...)
+	ach.hash.Write(hmacInput)
+	tag := ach.hash.Sum(nil)
+	ach.hash.Reset()
+
+	// Truncate HMAC to tagsize
+	tag = tag[:ach.tagSize]
+
+	result = append(result, tag...)
+	copy(dst, result)
+	return result
+}
+
+var errOpen = errors.New("aes-cbc-hmac: AEAD - Open failed")
+
+func (ach *aesCbcHmac) Open(dst, nonce, ciphertext, data []byte) ([]byte, error) {
+	if len(nonce) != ach.nonceSize {
+		panic("aes-cbc-hmac: Nonce Length does not match!")
+	}
+
+	if len(ciphertext) < ach.tagSize {
+		return nil, errOpen
+	}
+
+	if uint64(len(ciphertext)) > ((1<<32)-2)*uint64(ach.cipher.BlockSize())+uint64(ach.tagSize) {
+		return nil, errOpen
+	}
+
+	tag := ciphertext[len(ciphertext)-ach.tagSize:]
+	ciphertext = ciphertext[:len(ciphertext)-ach.tagSize]
+
+	// Calculate tag to compare with actual tag
+	// HMAC input is nonce N + Associated data A + ciphertext
+	// Refer to RFC5116 at: https://tools.ietf.org/html/rfc5116
+	hmacInput := make([]byte, len(nonce)+len(data)+len(ciphertext))
+	copy(hmacInput, nonce)
+	hmacInput = append(hmacInput, data...)
+	hmacInput = append(hmacInput, ciphertext...)
+
+	ach.hash.Write(hmacInput)
+	evaluatedTag := ach.hash.Sum(nil)
+	ach.hash.Reset()
+
+	// Truncate HMAC to tagsize
+	evaluatedTag = evaluatedTag[:ach.tagSize]
+
+	// Compare tags
+	if !hmac.Equal(tag, evaluatedTag) {
+		return nil, errOpen
+	}
+
+	// iff tag is valid, only then we proceed with decryption
+	return ach.decryptCiphertext(ciphertext)
+}
+
+// Helper function to decrypt the ciphertext, verify and strip
+// the PKCS#7 padding and return the resulting plaintext
+func (ach *aesCbcHmac) decryptCiphertext(cipherText []byte) ([]byte, error) {
+	iv := cipherText[:achBlockSize]
+	cipherText = cipherText[achBlockSize:]
+
+	// Ciphertext should be an even multiple of block size
+	if len(cipherText)%achBlockSize != 0 {
+		return nil, errOpen
+	}
+
+	result := make([]byte, len(cipherText))
+	copy(result, cipherText)
+	mode := cipher.NewCBCDecrypter(ach.cipher, iv)
+	mode.CryptBlocks(result, result)
+
+	// Remove and verify PKCS#7 padding for cbc
+	c := result[len(result)-1]
+	paddingSize := int(c)
+	size := len(result) - paddingSize
+	err := error(nil)
+
+	if paddingSize == 0 || paddingSize > len(result) {
+		err = errOpen
+	}
+	for i := 0; i < paddingSize; i++ {
+		if result[size+i] != c {
+			err = errOpen
+		}
+	}
+
+	// If there are issues with the PKCS#7 padding return error
+	if err != nil {
+		return nil, err
+	}
+
+	return result[:size], nil
+
+}


### PR DESCRIPTION
The current AES-CBC encryption provider does not provide ciphertext integrity, and is susceptible to certain vectors of attack (including Padding Oracle attacks). To fix this, we add support for an AEAD provider based on AES-CBC and HMAC based message authentication codes. 